### PR TITLE
Adding sendAccountBalanceData action for lftcrv plugin

### DIFF
--- a/src/lib/agent/plugins/leftcurve/actions/paradexActions/sendAccountBalanceToBackend.ts
+++ b/src/lib/agent/plugins/leftcurve/actions/paradexActions/sendAccountBalanceToBackend.ts
@@ -1,0 +1,58 @@
+import { StarknetAgentInterface } from "src/lib/agent/tools/tools";
+import { BalanceService } from "../../../paradex/actions/fetchAccountBalance";
+import { getParadexConfig } from "../../utils/getParadexConfig";
+import { getAccount, ParadexAuthenticationError } from "../../../paradex/utils/utils";
+import { authenticate } from "../../../paradex/utils/paradex-ts/api";
+import { ParadexBalanceError } from "../../../paradex/interfaces/errors";
+import { sendAccountBalanceData } from "../../utils/sendAccountBalanceData";
+import { getContainerId } from "../../utils/getContainerId";
+
+export const sendParadexBalance = async (agent: StarknetAgentInterface) => {
+  console.info('Calling sendParadexBalance');
+  console.log('Calling sendParadexBalance');
+  const service = new BalanceService();
+  try {
+    const config = await getParadexConfig();
+
+    const account = await getAccount();
+
+    try {
+      account.jwtToken = await authenticate(config, account);
+    } catch (error) {
+      console.error('Authentication failed:', error);
+      throw new ParadexAuthenticationError(
+        'Failed to authenticate with Paradex',
+        error
+      );
+    }
+    console.info('Authentication successful');
+
+    const balanceData = await service.fetchAccountBalance(config, account);
+
+    const formattedResponse = service.formatBalanceResponse(
+      balanceData.results
+    );
+    console.log(formattedResponse.text);
+
+    const accountBalanceDto = {
+      runtimeAgentId: getContainerId(),
+      balanceInUSD: formattedResponse.balance?.size,
+    };
+    console.info('accountBalanceDto', accountBalanceDto);
+    console.log('accountBalanceDto', accountBalanceDto);
+    await sendAccountBalanceData(accountBalanceDto);
+    return true;
+
+  } catch (error) {
+    if (error instanceof ParadexBalanceError) {
+      console.error('Balance error:', error.details || error.message);
+    } else {
+      console.error('Unexpected error fetching balance:', error);
+    }
+    return {
+      success: false,
+      data: null,
+      text: 'Failed to fetch account balance. Please try again later.',
+    };
+  }
+};

--- a/src/lib/agent/plugins/leftcurve/tools/index.ts
+++ b/src/lib/agent/plugins/leftcurve/tools/index.ts
@@ -30,6 +30,7 @@ import { paradexGetBalance } from '../../paradex/actions/fetchAccountBalance';
 import { paradexGetBBO } from '../../paradex/actions/getBBO';
 import { paradexListMarkets } from '../../paradex/actions/listMarketsOnParadex';
 import { getAnalysisParadex } from '../actions/paradexActions/fetchBackendAnalysis';
+import { sendParadexBalance } from '../actions/paradexActions/sendAccountBalanceToBackend';
 
 export const registerLftcrvTools = () => {
   StarknetToolRegistry.registerTool({
@@ -127,6 +128,14 @@ export const registerLftcrvTools = () => {
     description: 'Get account balance on Paradex exchange (USDC)',
     schema: getBalanceSchema,
     execute: paradexGetBalance,
+  });
+
+  StarknetToolRegistry.registerTool({
+    name: 'send_balance_paradex',
+    plugins: 'lftcrv',
+    description: 'Always sends your Paradex balance to the backend with this function after any action on Paradex.',
+    schema: getBalanceSchema,
+    execute: sendParadexBalance,
   });
 
   StarknetToolRegistry.registerTool({

--- a/src/lib/agent/plugins/leftcurve/utils/sendAccountBalanceData.ts
+++ b/src/lib/agent/plugins/leftcurve/utils/sendAccountBalanceData.ts
@@ -1,0 +1,43 @@
+export const sendAccountBalanceData = async (accountBalanceDto: any): Promise<void> => {
+    try {
+      const backendPort = process.env.BACKEND_PORT || '8080';
+      const isLocal = process.env.LOCAL_DEVELOPMENT === 'TRUE';
+      const host = isLocal ? process.env.HOST : '172.17.0.1';
+      const apiKey = process.env.BACKEND_API_KEY;
+  
+      console.log(
+        'Sending trading info to:',
+        `http://${host}:${backendPort}/api/kpi`
+      );
+  
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+  
+      if (apiKey) {
+        headers['x-api-key'] = apiKey;
+      }
+  
+      const response = await fetch(
+        `http://${host}:${backendPort}/api/kpi`,
+        {
+          method: 'POST',
+          headers,
+          body: JSON.stringify(accountBalanceDto),
+        }
+      );
+  
+      if (!response.ok) {
+        throw new Error(
+          `Failed to save trading info: ${response.status} ${response.statusText}`
+        );
+      }
+  
+      const data = await response.json();
+    } catch (error) {
+      console.error(
+        'Error saving trading information:',
+        error.response?.data || error.message
+      );
+    }
+  }


### PR DESCRIPTION
Addition of the sendAccountBalanceData action, which will be called after each action related to Paradex. The function sends the Account Balance Data according to the DTO expected by the lftcrv-backend